### PR TITLE
Specify type of Newton's Method within .cfg file for 2T in M++

### DIFF
--- a/Common/include/CConfig.hpp
+++ b/Common/include/CConfig.hpp
@@ -1222,7 +1222,8 @@ private:
   Supercatalytic_Wall;                      /*!< \brief Flag for supercatalytic wall. */
   string GasModel,                          /*!< \brief Gas Model. */
   *Wall_Catalytic;                          /*!< \brief Pointer to catalytic walls. */
-  string NoneqStateModel;                   /*!< \brief Nonequilibtrium State Model. */
+  string NoneqStateModel;                   /*!< \brief Nonequilibrium State Model. */
+  bool Newton_2T;                           /*!< \brief M++ derivative vs. Perturbation Method for Newton's Method. */
   TRANSCOEFFMODEL   Kind_TransCoeffModel;   /*!< \brief Transport coefficient Model for NEMO solver. */
   su2double CatalyticEfficiency;            /*!< \brief Wall catalytic efficiency. */
   su2double *Inlet_MassFrac;                /*!< \brief Specified Mass fraction vectors for NEMO inlet boundaries. */
@@ -3821,6 +3822,13 @@ public:
    * \return Nonequilibrium state model that we are using.
    */
   string GetNoneqStateModel(void) const {return NoneqStateModel;}
+
+    /*!
+   * \brief 2T Nonequilibrium numerical method to solve for temperatures.
+   * \return Bool to use M++ implementation vs. Perturbation Method.
+   */
+  bool Get2TNewton(void) const {return Newton_2T;}
+
 
   /*!
    * \brief Get the transport coefficient model.

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1228,8 +1228,10 @@ void CConfig::SetConfig_Options() {
   /*--- Reading gas model as string or integer depending on TC library used. ---*/
   /* DESCRIPTION: Specify chemical model for multi-species simulations - read by Mutation++ library*/
   addStringOption("GAS_MODEL", GasModel, string("N2"));
-  /* DESCRIPTION: Specify transport coefficient model for multi-species simulations */
+  /* DESCRIPTION: Specify Nonequilibrium Temperature Model */
   addStringOption("NONEQ_STATE_MODEL", NoneqStateModel, string("2T"));
+  /* DESCRIPTION: Specify M++ Derivative vs. Perturbation Method for Newton's Method solving for temperatures */
+  addBoolOption("2T_NEWTON", Newton_2T, true);
   /* DESCRIPTION: Specify transport coefficient model for multi-species simulations */
   addEnumOption("TRANSPORT_COEFF_MODEL", Kind_TransCoeffModel, TransCoeffModel_Map, TRANSCOEFFMODEL::WILKE);
   /* DESCRIPTION: Specify mass fraction of each species */

--- a/SU2_CFD/include/fluid/CMutationTCLib.hpp
+++ b/SU2_CFD/include/fluid/CMutationTCLib.hpp
@@ -58,6 +58,8 @@ private:
 
   su2double Tref;                         /*!< \brief Reference temperature. */
 
+  bool NEWTON;                             /*!< \brief Boolean to use Newton-Raphson h/cp or Perturbation Method to calculate Jacobian. */
+
 public:
 
   /*!

--- a/SU2_CFD/src/fluid/CMutationTCLib.cpp
+++ b/SU2_CFD/src/fluid/CMutationTCLib.cpp
@@ -56,6 +56,7 @@ CMutationTCLib::CMutationTCLib(const CConfig* config, unsigned short val_nDim): 
   else if (Kind_TransCoeffModel == TRANSCOEFFMODEL::CHAPMANN_ENSKOG)
     transport_model = "Chapmann-Enskog_LDLT";
 
+  NEWTON = config->Get2TNewton();
   if (NoneqStateModel == "2T") {
       opt.setStateModel("ChemNonEqTTv");
   }
@@ -137,7 +138,7 @@ void CMutationTCLib::SetTDStateRhosTTv(vector<su2double>& val_rhos, su2double va
 
   Pressure = ComputePressure();
 
-  mix->setState(rhos.data(), temperatures.data(), 1);
+  mix->setState(rhos.data(), temperatures.data(), 1, NEWTON);
 
 }
 
@@ -295,7 +296,7 @@ vector<su2double>& CMutationTCLib::ComputeTemperatures(vector<su2double>& val_rh
   energies[0] = rhoE - rhoEvel;
   energies[1] = rhoEve;
 
-  mix->setState(rhos.data(), energies.data(), 0);
+  mix->setState(rhos.data(), energies.data(), 0, NEWTON);
 
   mix->getTemperatures(temperatures.data());
 

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -425,6 +425,8 @@ GAS_COMPOSITION= (0.77, 0.23, 0.0, 0.0, 0.0)
 FROZEN_MIXTURE= NO
 % 1-Temperature vs. 2-Temperature Model for Mutation++
 NONEQ_STATE_MODEL= 2T
+% Use Mutationpp h/cp relation for solving for 2T temperatures vs. Perturbation Method
+2T_NEWTON= YES
 %
 % Datadriven fluid model
 % For data-driven fluid models, an interpolation algorithm is used to retrieve the thermodynamic state for a given density and internal energy


### PR DESCRIPTION
## Proposed Changes
*Give a brief overview of your contribution here in a few sentences.*

Using .cfg file, you can specify to use M++'s 2T temperature calculation using h/cp or to use a finite difference perturbation method to solve for the Jacobian.

## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [ ] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [ ] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
